### PR TITLE
Declare config as a global variable so it is not ignored

### DIFF
--- a/PicoZCache.php
+++ b/PicoZCache.php
@@ -22,6 +22,7 @@ class PicoZCache extends AbstractPicoPlugin
 
     public function onConfigLoaded(array &$settings)
     {
+        global $config;
         if (isset($config['cache_dir'])) {
 
             // ensure cache_dir ends with '/'


### PR DESCRIPTION
Hi,

Thanks for the plugin, but the configuration was ignored because you need to tell php that it's a globale variable, I've made the fix